### PR TITLE
Made normalization switchable (vst/rlog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,22 @@
 
 ### Added
 
-- Add parameter "--skip_pathway_analysis"
+- [#104](https://github.com/qbic-pipelines/rnadeseq/pull/104) Add parameter "--skip_pathway_analysis"
 - Bump versions to 1.4.0dev
 - Add parameter "--min_DE_genes"
-- Update pipeline to DSL2
-- Add parameter "--skip_rlog"
+- [#97](https://github.com/qbic-pipelines/rnadeseq/pull/97) Update pipeline to DSL2
+- [#107](https://github.com/qbic-pipelines/rnadeseq/pull/107) Add parameter "--skip_rlog"
 
 ### Changed
 
 - Removed assets/report_options.yml
+- [#110](https://github.com/qbic-pipelines/rnadeseq/pull/110) Changed report to use rlog normalization by default, vst is used if --skip_rlog is enabled
 
 ### Fixed
 
 - [#105](https://github.com/qbic-pipelines/rnadeseq/pull/105) Fixed relevel and added test_relevel.config
-- Fixed `--logFCthreshold` bug
-- Fixed blacklist file not working
+- [#106](https://github.com/qbic-pipelines/rnadeseq/pull/106) Fixed `--logFCthreshold` bug
+- [#108](https://github.com/qbic-pipelines/rnadeseq/pull/108) Fixed blacklist file not working
 
 ## 1.3.2 - Almond Blossoms hotfix II
 

--- a/assets/RNAseq_report.Rmd
+++ b/assets/RNAseq_report.Rmd
@@ -25,6 +25,7 @@ params:
     log_FC: ""
     revision: ""
     pathway_analysis: ""
+    rlog: ""
 # Author: Silvia Morini, Gisela Gabernet, Simon Heumos
 ---
 
@@ -304,8 +305,12 @@ The differential expression analysis is performed using the raw gene count table
 For PCA analysis and heatmap plotting, the regularized logarithm (rlog) normalized gene counts were employed.
 The vst (variant stabilizing transformation) normalized counts are also provided.
 
+```{r}
+rlog_text <- ifelse(params$rlog, "rlog", "vst")
+```
+
 ## Principal component analysis (PCA)
-A PCA plot of the rlog normalized gene expression visualizes the clustering of samples according to their gene expression.
+A PCA plot of the `r rlog_text` normalized gene expression visualizes the clustering of samples according to their gene expression.
 In this way, the overall effect of experimental conditions and sample grouping, and any batch effects are visualized.
 The original plot can be downloaded [here](./differential_gene_expression/plots/PCA_plot.pdf).
 

--- a/assets/RNAseq_report.Rmd
+++ b/assets/RNAseq_report.Rmd
@@ -296,18 +296,18 @@ knitr::include_graphics(paste0(wd, "/QC/multiqc_plots/svg/mqc_rseqc_read_distrib
 </center>
 \
 
+```{r}
+rlog_text <- ifelse(params$rlog, "rlog", "vst")
+rlog_long_text <- ifelse(params$rlog, "regularized logarithm (rlog)", "variant stabilizing transformation (vst)")
+```
+
 # Gene expression data
 
 ## Raw and normalized count tables
 
 The raw count table and normalized count tables are available [here](./differential_gene_expression/gene_counts_tables).
 The differential expression analysis is performed using the raw gene count table.
-For PCA analysis and heatmap plotting, the regularized logarithm (rlog) normalized gene counts were employed.
-The vst (variant stabilizing transformation) normalized counts are also provided.
-
-```{r}
-rlog_text <- ifelse(params$rlog, "rlog", "vst")
-```
+For PCA analysis and heatmap plotting, the `r rlog_long_text` normalized gene counts were employed.
 
 ## Principal component analysis (PCA)
 A PCA plot of the `r rlog_text` normalized gene expression visualizes the clustering of samples according to their gene expression.

--- a/bin/DESeq2.R
+++ b/bin/DESeq2.R
@@ -460,7 +460,7 @@ dev.off()
 
 
 ############################ PCA PLOTS ########################
-pcaData <- plotPCA(vsd,intgroup=c("combfactor"),ntop = dim(vsd)[1], returnData=TRUE)
+pcaData <- plotPCA(if (opt$rlog) rld else vsd,intgroup=c("combfactor"),ntop = dim(vsd)[1], returnData=TRUE)
 percentVar <- round(100*attr(pcaData, "percentVar"))
 pca <- ggplot(pcaData, aes(PC1, PC2, color=combfactor)) +
     geom_point(size=3) +
@@ -473,8 +473,13 @@ ggsave(plot = pca, filename = "differential_gene_expression/plots/PCA_plot.svg",
 
 ########################### PCA PLOT with batch-corrected data ############
 if(opt$batchEffect){
-    assay(vsd) <- limma::removeBatchEffect(assay(vsd), vsd$batch)
-    pcaData2 <- plotPCA(vsd, intgroup=c("combfactor"), ntop = dim(vsd)[1], returnData=TRUE)
+    if(opt$rlog){
+        assay(rld) <- limma::removeBatchEffect(assay(rld), rld$batch)
+        pcaData2 <- plotPCA(rld, intgroup=c("combfactor"), ntop = dim(rld)[1], returnData=TRUE)
+    } else {
+        assay(vsd) <- limma::removeBatchEffect(assay(vsd), vsd$batch)
+        pcaData2 <- plotPCA(vsd, intgroup=c("combfactor"), ntop = dim(vsd)[1], returnData=TRUE)
+    }
     percentVar <- round(100*attr(pcaData, "percentVar"))
     pca2 <- ggplot(pcaData2, aes(PC1, PC2, color=combfactor)) +
                 geom_point(size=3)+

--- a/bin/DESeq2.R
+++ b/bin/DESeq2.R
@@ -373,19 +373,18 @@ DE_genes_final_table = DE_genes_final_table[order(DE_genes_final_table[,"Ensembl
 write.table(DE_genes_final_table, "differential_gene_expression/final_gene_table/final_DE_gene_list.tsv", append = FALSE, quote = FALSE, sep = "\t",eol = "\n", na = "NA", dec = ".", row.names = F,  col.names = T, qmethod = c("escape", "double"))
 
 ############################## TRANSFORMED AND NORMALIZED COUNTS ###################
-# rlog transformation
 if (opt$rlog){
+    # rlog transformation
     rld <- rlog(cds, blind=FALSE)
     rld_names <- merge(x=gene_names, y=assay(rld), by.x = "Ensembl_ID", by.y="row.names")
     write.table(rld_names, "differential_gene_expression/gene_counts_tables/rlog_transformed_gene_counts.tsv", append = FALSE, quote = FALSE, sep = "\t",eol = "\n", na = "NA", dec = ".", row.names = F,  qmethod = c("escape", "double"))
+} else {
+    # vst transformation
+    vsd <- vst(cds, blind=FALSE)
+    vsd_names <- merge(x=gene_names, y=assay(vsd), by.x = "Ensembl_ID", by.y="row.names")
+    write.table(vsd_names, "differential_gene_expression/gene_counts_tables/vst_transformed_gene_counts.tsv", append = FALSE, quote = FALSE, sep = "\t",eol = "\n", na = "NA", dec = ".", row.names = F, qmethod = c("escape", "double"))
 }
 
-# vst transformation
-vsd <- vst(cds, blind=FALSE)
-
-# write normalized values to a file
-vsd_names <- merge(x=gene_names, y=assay(vsd), by.x = "Ensembl_ID", by.y="row.names")
-write.table(vsd_names, "differential_gene_expression/gene_counts_tables/vst_transformed_gene_counts.tsv", append = FALSE, quote = FALSE, sep = "\t",eol = "\n", na = "NA", dec = ".", row.names = F, qmethod = c("escape", "double"))
 
 
 ############### BOXPLOTS GENE EXPRESSION PER CONDITION ##########################
@@ -445,7 +444,7 @@ if (!is.null(opt$genelist)){
 
 ##################  SAMPLE DISTANCES HEATMAP ##################
 # Sample distances
-sampleDists <- dist(t(assay(vsd)))
+sampleDists <- dist(t(assay(if (opt$rlog) rld else vsd)))
 sampleDistMatrix <- as.matrix(sampleDists)
 colours = colorRampPalette(rev(brewer.pal(9, "Blues")))(255)
 
@@ -460,7 +459,7 @@ dev.off()
 
 
 ############################ PCA PLOTS ########################
-pcaData <- plotPCA(if (opt$rlog) rld else vsd,intgroup=c("combfactor"),ntop = dim(vsd)[1], returnData=TRUE)
+pcaData <- plotPCA(if (opt$rlog) rld else vsd,intgroup=c("combfactor"),ntop = dim(if (opt$rlog) rld else vsd)[1], returnData=TRUE)
 percentVar <- round(100*attr(pcaData, "percentVar"))
 pca <- ggplot(pcaData, aes(PC1, PC2, color=combfactor)) +
     geom_point(size=3) +
@@ -473,13 +472,8 @@ ggsave(plot = pca, filename = "differential_gene_expression/plots/PCA_plot.svg",
 
 ########################### PCA PLOT with batch-corrected data ############
 if(opt$batchEffect){
-    if(opt$rlog){
-        assay(rld) <- limma::removeBatchEffect(assay(rld), rld$batch)
-        pcaData2 <- plotPCA(rld, intgroup=c("combfactor"), ntop = dim(rld)[1], returnData=TRUE)
-    } else {
-        assay(vsd) <- limma::removeBatchEffect(assay(vsd), vsd$batch)
-        pcaData2 <- plotPCA(vsd, intgroup=c("combfactor"), ntop = dim(vsd)[1], returnData=TRUE)
-    }
+    assay(if (opt$rlog) rld else vsd) <- limma::removeBatchEffect(assay(if (opt$rlog) rld else vsd), (if (opt$rlog) rld else vsd)$batch)
+    pcaData2 <- plotPCA(if (opt$rlog) rld else vsd, intgroup=c("combfactor"), ntop = dim(if (opt$rlog) rld else vsd)[1], returnData=TRUE)
     percentVar <- round(100*attr(pcaData, "percentVar"))
     pca2 <- ggplot(pcaData2, aes(PC1, PC2, color=combfactor)) +
                 geom_point(size=3)+
@@ -513,8 +507,8 @@ pdf("differential_gene_expression/plots/further_diagnostics_plots/Effects_of_tra
 par(oma=c(3,3,3,3))
 par(mfrow = c(1, 3))
 meanSdPlot(log2(counts(cds,normalized=TRUE)[notAllZero,] + 1),ylab  = "sd raw count data")
-if (opt$rlog){ meanSdPlot(assay(rld[notAllZero,]),ylab  = "sd rlog transformed count data") }
-meanSdPlot(assay(vsd[notAllZero,]),ylab  = "sd vst transformed count data")
+meanSdPlot(assay((if (opt$rlog) rld else vsd)[notAllZero,]),ylab  = "sd rlog transformed count data")
+meanSdPlot(assay((if (opt$rlog) rld else vsd)[notAllZero,]),ylab  = paste("sd ", if (opt$rlog) "rld" else "vsd" ," transformed count data"))
 dev.off()
 
 # Further diagnostics plots

--- a/bin/Execute_report.R
+++ b/bin/Execute_report.R
@@ -17,7 +17,8 @@ option_list = list(
     make_option(c("-f", "--log_FC"), type="double", default=NULL, help="Log Fold Change threshold to consider a gene DE."),
     make_option(c("-x", "--revision"), type="character", default=NULL, help="rnadeseq workflow revision", metavar="character"),
     make_option(c("-p", "--min_DEG_pathway"), type="integer", default=NULL, help="min. number of genes DE in a pathway for this pathway to be considered enriched.", metavar="integer"),
-    make_option(c("-a", "--pathway_analysis"), action="store_true", default=FALSE, help="Pathway analysis.")
+    make_option(c("-a", "--pathway_analysis"), action="store_true", default=FALSE, help="Pathway analysis."),
+    make_option(c("-y", "--rlog"), action="store_true", default=FALSE, help="Use rlog instead of vst normalization.")
 )
 
 opt_parser = OptionParser(option_list=option_list)
@@ -44,4 +45,5 @@ rmarkdown::render(opt$report, output_file = opt$output, knit_root_dir = wd, outp
                                 batch_effect = opt$batch_effect,
                                 log_FC = opt$log_FC,
                                 revision = opt$revision,
-                                pathway_analysis = opt$pathway_analysis))
+                                pathway_analysis = opt$pathway_analysis,
+                                rlog = opt$rlog))

--- a/conf/test_use_vst.config
+++ b/conf/test_use_vst.config
@@ -25,6 +25,7 @@ params {
   multiqc = 'https://raw.githubusercontent.com/qbic-pipelines/rnadeseq/dev/testdata/MultiQC.zip'
   quote = 'https://raw.githubusercontent.com/qbic-pipelines/rnadeseq/dev/testdata/offer_example.pdf'
   skip_pathway_analysis = false
-  skip_rlog = true
+  use_vst = true
   species = 'mmusculus'
+  logFCthreshold = 2
 }

--- a/modules/local/deseq2.nf
+++ b/modules/local/deseq2.nf
@@ -22,7 +22,7 @@ process DESEQ2 {
     def contrast_pairs_opt = contrast_pairs.name != 'DEFAULT2' ? "--contrasts_pairs $contrast_pairs" : ''
     def relevel_opt = relevel.name != 'NO_FILE2' ? "--relevel $relevel" : ''
     def batch_effect_opt = params.batch_effect ? "--batchEffect" : ''
-    def rlog_opt = params.skip_rlog ? '--rlog FALSE' : '--rlog TRUE'
+    def rlog_opt = params.use_vst ? '--rlog FALSE' : '--rlog TRUE'
     """
     DESeq2.R --counts $gene_counts --metadata $metadata --design $model \
     --logFCthreshold $params.logFCthreshold $relevel_opt $contrast_mat_opt \

--- a/modules/local/pathway_analysis.nf
+++ b/modules/local/pathway_analysis.nf
@@ -15,7 +15,7 @@ process PATHWAY_ANALYSIS {
     def genelistopt = genelist.name != 'NO_FILE' ? "--genelist $genelist" : ''
     def keggblacklistopt = keggblacklist.name != 'NO_FILE3' ? "--kegg_blacklist $keggblacklist" : ''
     def basepath = 'differential_gene_expression/gene_counts_tables/'
-    def normInput = params.skip_rlog ? basepath + 'vst_transformed_gene_counts.tsv' : basepath + 'rlog_transformed_gene_counts.tsv'
+    def normInput = params.use_vst ? basepath + 'vst_transformed_gene_counts.tsv' : basepath + 'rlog_transformed_gene_counts.tsv'
     """
     unzip $deseq_output
     pathway_analysis.R --dirContrasts 'differential_gene_expression/DE_genes_tables/' --metadata $metadata \

--- a/modules/local/report.nf
+++ b/modules/local/report.nf
@@ -22,6 +22,7 @@ process REPORT {
     def batchopt = params.batch_effect ? "--batch_effect" : ''
     def quoteopt = quote.name != 'NO_FILE4' ? "$quote" : ''
     def pathwayopt = params.skip_pathway_analysis ? '' : "--pathway_analysis"
+    def rlogopt = params.skip_rlog ? '' : "--rlog"
     """
     unzip $deseq2
     unzip $multiqc
@@ -42,7 +43,8 @@ process REPORT {
     --log_FC $params.logFCthreshold \
     $batchopt \
     --min_DEG_pathway $params.min_DEG_pathway \
-    $pathwayopt
+    $pathwayopt \
+    $rlogopt
     if [ "$pathwayopt" == "--pathway_analysis" ]; then
         zip -r report.zip RNAseq_report.html differential_gene_expression/ QC/ pathway_analysis/ $quoteopt
     else

--- a/modules/local/report.nf
+++ b/modules/local/report.nf
@@ -22,7 +22,7 @@ process REPORT {
     def batchopt = params.batch_effect ? "--batch_effect" : ''
     def quoteopt = quote.name != 'NO_FILE4' ? "$quote" : ''
     def pathwayopt = params.skip_pathway_analysis ? '' : "--pathway_analysis"
-    def rlogopt = params.skip_rlog ? '' : "--rlog"
+    def rlogopt = params.use_vst ? '' : "--rlog"
     """
     unzip $deseq2
     unzip $multiqc

--- a/nextflow.config
+++ b/nextflow.config
@@ -28,7 +28,7 @@ params {
     kegg_blacklist = 'NO_FILE3'
     quote = 'NO_FILE4'
     min_DEG_pathway = 1
-    skip_rlog = false
+    use_vst = false
     skip_pathway_analysis = false
 
     // Boilerplate options
@@ -113,7 +113,7 @@ profiles {
     test_blacklist { includeConfig 'conf/test_blacklist.config' }
     test_skip_pathway_analysis { includeConfig 'conf/test_skip_pathway_analysis.config' }
     test_relevel { includeConfig 'conf/test_relevel.config' }
-    test_skip_rlog { includeConfig 'conf/test_skip_rlog.config' }
+    test_use_vst { includeConfig 'conf/test_use_vst.config' }
 }
 
 /* TODO

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -101,14 +101,14 @@
                     "description": "Integer indicating how many genes in a pathway must be differentially expressed to be considered as enriched, and report these pathways in tables and the final report. The default value is 1."
                 },
                 "skip_pathway_analysis": {
-                    "type": "string",
+                    "type": "boolean",
                     "default": "false",
                     "description": "Turn on this flag if you wish to skip pathway analysis."
                 },
-                "skip_rlog": {
+                "use_vst": {
                     "type": "boolean",
                     "default": "false",
-                    "description": "Use this flag to skip rlog transformation (recommended when >50 samples)"
+                    "description": "Set this flag to true to use vst transformation (recommended when >50 samples; if false, will use rlog)"
                 }
             }
         },


### PR DESCRIPTION
Many thanks to contributing to qbic-pipelines!

This PR is in regard to issue #99 as a follow-up. It changes the DE analysis and report to use a vst normalization if rlog is skipped; otherwise, the rlog normalization is used.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/qbic-pipelines/rnadeseq/tree/master/.github/CONTRIBUTING.md
