### PR TITLE
add Athaliana db + turn LabID in metadata optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,5 @@ tests/test_data
 testing/
 testing*
 *.pyc
-deseq_dev.sh
+*.sh
 .gitignore

--- a/assets/RNAseq_report.Rmd
+++ b/assets/RNAseq_report.Rmd
@@ -130,16 +130,17 @@ if(file.exists(QAfile)){
     df_QA <- read.table(QAfile, header=TRUE, sep="\t", check.names = FALSE)
     conditions <- grepl(colnames(df_QA),pattern = "Condition")
     df_QA_cond <- as.data.frame(df_QA[ ,conditions])
-    colnames(df_QA_cond) <- colnames(df_QA)[conditions]
-    df_QA_neat <- df_QA[,c("QBiC Code", "Secondary Name", "Lab ID", "Sample Type")]
+    colnames(df_QA_cond) <- colnames(df_QA)[conditions] 
+    df_QA_neat <- df_QA[,c("QBiC Code", "Secondary Name", "Sample Type")]
+    if ("Lab ID" %in% colnames(df_QA)){
+            df_QA_neat[,c("Lab ID")] <- df_QA[,c("Lab ID")]}
+        } 
     df_QA_neat <- merge(df_QA_neat, df_QA_cond, by="row.names")
     df_QA_neat$Row.names <- NULL
     if ("RIN" %in% colnames(df_QA)){
         if (any(is.na(df_QA$RIN))){no_RIN <- TRUE} else {RIN <- TRUE; df_QA_neat$RIN <- df_QA$RIN}
     } else {no_RIN <- TRUE}
-} else {
-    no_RIN <- TRUE
-}
+
 ```
 
 ```{r RIN_block, echo=FALSE, results='asis', eval=RIN}

--- a/assets/RNAseq_report.Rmd
+++ b/assets/RNAseq_report.Rmd
@@ -130,11 +130,16 @@ if(file.exists(QAfile)){
     df_QA <- read.table(QAfile, header=TRUE, sep="\t", check.names = FALSE)
     conditions <- grepl(colnames(df_QA),pattern = "Condition")
     df_QA_cond <- as.data.frame(df_QA[ ,conditions])
-    colnames(df_QA_cond) <- colnames(df_QA)[conditions] 
-    df_QA_neat <- df_QA[,c("QBiC Code", "Secondary Name", "Sample Type")]
+    colnames(df_QA_cond) <- colnames(df_QA)[conditions]
+    df_QA_neat <- df_QA[,c("QBiC Code", "Secondary Name")]
+    #add "Sample Type" only if present in metadata.tsv
+    if ("Sample Type" %in% colnames(df_QA)) {
+            df_QA_neat[,c("Sample Type")] <- df_QA[,c("Sample Type")]
+    }
+    #add "Lab ID" only if present in metadata.tsv
     if ("Lab ID" %in% colnames(df_QA)){
             df_QA_neat[,c("Lab ID")] <- df_QA[,c("Lab ID")]}
-        } 
+        }
     df_QA_neat <- merge(df_QA_neat, df_QA_cond, by="row.names")
     df_QA_neat$Row.names <- NULL
     if ("RIN" %in% colnames(df_QA)){

--- a/bin/pathway_analysis.R
+++ b/bin/pathway_analysis.R
@@ -249,10 +249,8 @@ for (file in contrast_files){
             pathway <- df[i,]
             gene_list <- unlist(strsplit(pathway$intersection, ","))
             mat <- norm_counts[gene_list, ]
-            #check if gene names are unique (e.g. TAIR database has multiple names PYRD for different geneIDs)
-            #if (length(mat$gene_name)!=length(unique(mat$gene_name))) {
+            #Turn gene names unique, in case there are duplicates (e.g. TAIR database has multiple names PYRD for different geneIDs)
             mat$gene_name <- with(mat, make.unique(as.character(gene_name)))
-            #}
             rownames(mat) <- mat$gene_name
             mat$gene_name <- NULL
             mat <- data.matrix(mat)

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
     - bioconda::bioconductor-genomeinfodbdata=1.2.7
     - bioconda::bioconductor-org.hs.eg.db=3.14.0
     - bioconda::bioconductor-org.mm.eg.db=3.14.0
+    - bioconda::bioconductor-org.At.tair.db=3.14.0
     - bioconda::bioconductor-pathview=1.34.0
     - bioconda::bioconductor-vsn=3.62.0
     - conda-forge::pandoc=2.17.1.1

--- a/nextflow.config
+++ b/nextflow.config
@@ -48,7 +48,7 @@ params {
 
 // Container slug. Stable releases should specify release tag!
 // Developmental code should specify :dev
-process.container = 'qbicpipelines/rnadeseq:dev'
+process.container = 'tair_container'
 
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'
@@ -158,7 +158,7 @@ dag {
 }
 
 // Container definition
-process.container = "qbicpipelines/rnadeseq:dev"
+//process.container = "qbicpipelines/rnadeseq:dev"
 
 manifest {
     name            = 'qbic-pipelines/rnadeseq'

--- a/nextflow.config
+++ b/nextflow.config
@@ -48,7 +48,7 @@ params {
 
 // Container slug. Stable releases should specify release tag!
 // Developmental code should specify :dev
-process.container = 'tair_container'
+process.container = 'qbicpipelines/rnadeseq:dev'
 
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'
@@ -156,9 +156,6 @@ dag {
     enabled = true
     file    = "${params.tracedir}/pipeline_dag_${trace_timestamp}.svg"
 }
-
-// Container definition
-//process.container = "qbicpipelines/rnadeseq:dev"
 
 manifest {
     name            = 'qbic-pipelines/rnadeseq'


### PR DESCRIPTION
The Arabidopsis thaliana database was added and the R code (pathway_analysis.R) changed accordingly. The database path was also added to the environment.yml. It was tested and ran with A. thaliana data locally.  
In addition the entry of "Lab ID" in the metadata sheet was turned optional for the generation of the report (RNAseq_report.Rmd).

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/qbic-pipelines/rnadeseq/tree/master/.github/CONTRIBUTING.md
