### PR TITLE
Updated doc, fixed relevel bug, added relevel to github tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,10 @@ jobs:
             "test",
             "test_contrast_matrix",
             "test_contrast_list",
+            "test_relevel",
             "test_skip_pathway_analysis",
-            "test_star_salmon",
             "test_star_rsem",
+            "test_star_salmon",
             "test_use_vst",
           ]
     steps:

--- a/.github/workflows/linting_comment.yml
+++ b/.github/workflows/linting_comment.yml
@@ -26,4 +26,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           number: ${{ steps.pr_number.outputs.pr_number }}
           path: linting-logs/lint_results.md
-#

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- [#125](https://github.com/qbic-pipelines/rnadeseq/pull/125) Added test_relevel to github tests, added explanation to usage.md that --species is not necessary if skipping pathway analysis
 - [#123](https://github.com/qbic-pipelines/rnadeseq/pull/123) Export report volcano plots as SVG; save all plots additionally as PDF
 - [#122](https://github.com/qbic-pipelines/rnadeseq/pull/122) Add searchable/sortable tables to report
 - [#118](https://github.com/qbic-pipelines/rnadeseq/pull/118) Add parameter "--input_type" (and change --rawcounts to --gene_counts) to process featurecounts, rsem and salmon output from the new rnaseq; add igenomes.config to process different species
@@ -23,7 +24,7 @@
 - [#110](https://github.com/qbic-pipelines/rnadeseq/pull/110) Changed report to use rlog normalization by default, vst is used if --skip_rlog is enabled
 
 ### Fixed
-
+- [#125](https://github.com/qbic-pipelines/rnadeseq/pull/125) Fixed relevel bug
 - [#118](https://github.com/qbic-pipelines/rnadeseq/pull/118) Removed blacklist parameter and config and instead added trycatch to ignore pathways with errors
 - [#105](https://github.com/qbic-pipelines/rnadeseq/pull/105) Fixed relevel and added test_relevel.config
 - [#106](https://github.com/qbic-pipelines/rnadeseq/pull/106) Fixed `--logFCthreshold` bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [#110](https://github.com/qbic-pipelines/rnadeseq/pull/110) Changed report to use rlog normalization by default, vst is used if --skip_rlog is enabled
 
 ### Fixed
+
 - [#125](https://github.com/qbic-pipelines/rnadeseq/pull/125) Fixed relevel bug
 - [#118](https://github.com/qbic-pipelines/rnadeseq/pull/118) Removed blacklist parameter and config and instead added trycatch to ignore pathways with errors
 - [#105](https://github.com/qbic-pipelines/rnadeseq/pull/105) Fixed relevel and added test_relevel.config

--- a/bin/DESeq2.R
+++ b/bin/DESeq2.R
@@ -177,17 +177,6 @@ design <- read.csv(path_design, sep="\t", header = F)
 write.table(design, file="differential_gene_expression/metadata/linear_model.txt", sep="\t", quote=F, col.names = F, row.names = F)
 
 ################## RUN DESEQ2 ######################################
-#Apply relevel if provided to metadata
-if (!is.null(opt$relevel)) {
-    relevel_table <- read.table(path_relevel, sep="\t", header = T, colClasses = "character")
-    write.table(relevel_table, file="differential_gene_expression/metadata/relevel.tsv")
-
-    for (i in c(1:nrow(relevel_table))) {
-        relev <- relevel_table[i,]
-        cds[[paste(relev[1])]] <- relevel(cds[[paste(relev[1])]], paste(relev[2]))
-    }
-}
-
 # Run DESeq function
 if (opt$input_type == "featurecounts") {
     cds <- DESeqDataSetFromMatrix( countData =count.table, colData =metadata, design = eval(parse(text=as.character(design[[1]]))))
@@ -260,6 +249,16 @@ if (opt$input_type == "featurecounts") {
     }
 } else {
     stop("Input type must be one of [featurecounts, rsem, salmon]!")
+}
+#Apply relevel if provided to metadata
+if (!is.null(opt$relevel)) {
+    relevel_table <- read.table(path_relevel, sep="\t", header = T, colClasses = "character")
+    write.table(relevel_table, file="differential_gene_expression/metadata/relevel.tsv")
+
+    for (i in c(1:nrow(relevel_table))) {
+        relev <- relevel_table[i,]
+        cds[[paste(relev[1])]] <- relevel(cds[[paste(relev[1])]], paste(relev[2]))
+    }
 }
 # SizeFactors(cds) as indicator of library sequencing depth
 write.table(sizeFactors(cds),paste("differential_gene_expression/gene_counts_tables/sizeFactor_libraries.tsv",sep=""), append = FALSE, quote = FALSE, sep = "\t",eol = "\n", na = "NA", dec = ".", row.names = T,  col.names = F, qmethod = c("escape", "double"))

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -168,7 +168,7 @@ Linear model function to calculate the contrasts (TXT). Variable names should be
 
 ### `--species`
 
-Species name. Currently the following species are available for pathway analysis: Hsapiens, Mmusculus. To include new species, please open an issue with the species full scientific name.
+Species name, not necessary if --skip_pathway_analysis = true. Currently the following species are available for pathway analysis: Hsapiens, Mmusculus. To include new species, please open an issue with the species full scientific name.
 
 ### `--project_summary`
 


### PR DESCRIPTION
Many thanks to contributing to qbic-pipelines!

This PR fixes a relevel bug and adds test_relevel to the github checks. It also updates the doc to state that the --species param is unnecessary if skipping pathway analysis.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/qbic-pipelines/rnadeseq/tree/master/.github/CONTRIBUTING.md
