### PR TITLE
Checking md5sum consistency

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -68,10 +68,6 @@ params {
     schema_ignore_params  = null
 }
 
-// Container slug. Stable releases should specify release tag!
-// Developmental code should specify :dev
-// process.container = 'qbicpipelines/rnadeseq:dev'
-
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'
 

--- a/tests/test_batcheffect.yml
+++ b/tests/test_batcheffect.yml
@@ -4,15 +4,15 @@
     - test_batcheffect
   files:
     - path: results_test/differential_gene_expression/DE_genes_tables/DE_contrast_batch_b2_vs_b1.tsv
-      md5sum: 389c1a89072623acfb0e850d254c763f #4c8bcede761f82803c262f28a13eb5ce
+      md5sum: 4c8bcede761f82803c262f28a13eb5ce
     - path: results_test/differential_gene_expression/DE_genes_tables/DE_contrast_batch_b3_vs_b1.tsv
-      md5sum: 4ef9be56cf2c2d3a8a1aa2b4c8e159a5 #94b10670ba4dbba7596ee3dcae46e8ea
+      md5sum: 94b10670ba4dbba7596ee3dcae46e8ea
     - path: results_test/differential_gene_expression/DE_genes_tables/DE_contrast_condition_genotype_WT_vs_KO.tsv
-      md5sum: da291c2a1c1fb2fd0d9c3059010a7800 #e698fbecc341bd59ce7d47dfab77d642
+      md5sum: e698fbecc341bd59ce7d47dfab77d642
     - path: results_test/differential_gene_expression/DE_genes_tables/DE_contrast_condition_treatment_Treated_vs_Control.tsv
-      md5sum: 8ec60640f4331b08648fdc3caf78e2c2 #2738119f899ecd154cd5cfc40e1e24e4
+      md5sum: 2738119f899ecd154cd5cfc40e1e24e4
     - path: results_test/differential_gene_expression/final_gene_table/final_DE_gene_list.tsv
-      md5sum: 2dbf14c38923324ffe059f5ac220b612 #ad0df4e1d022ba7fd56df6a5e594a281
+      md5sum: ad0df4e1d022ba7fd56df6a5e594a281
     - path: results_test/differential_gene_expression/gene_counts_tables/deseq2_table.tsv
     - path: results_test/differential_gene_expression/gene_counts_tables/raw_gene_counts.tsv
     - path: results_test/differential_gene_expression/gene_counts_tables/rlog_transformed_gene_counts.tsv


### PR DESCRIPTION
This is a test PR to see if the batcheffect test md5sums are now constant

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnadeseq/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/rnadeseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
