### PR TITLE
Changed relevel github path to qbic-pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#204](https://github.com/qbic-pipelines/rnadeseq/pull/204) Changed relevel path in test_relevel.config to the qbic-pipelines repo
 - [#203](https://github.com/qbic-pipelines/rnadeseq/pull/203) Switched from Dockerhub to GHCR
 - [#200](https://github.com/qbic-pipelines/rnadeseq/pull/200) Made software_versions optional
 - [#198](https://github.com/qbic-pipelines/rnadeseq/pull/198) Changed heatmaps to scale in size automatically

--- a/conf/test_relevel.config
+++ b/conf/test_relevel.config
@@ -18,7 +18,7 @@ params {
     input = 'https://raw.githubusercontent.com/qbic-pipelines/rnadeseq/dev/testdata/Sample_preparations.tsv'
     gene_counts = 'https://raw.githubusercontent.com/qbic-pipelines/rnadeseq/dev/testdata/merged_gene_counts.txt'
     model = 'https://raw.githubusercontent.com/qbic-pipelines/rnadeseq/dev/testdata/design.txt'
-    relevel = 'https://raw.githubusercontent.com/SusiJo/rnadeseq/dev/testdata/relevel.tsv'
+    relevel = 'https://raw.githubusercontent.com/qbic-pipelines/rnadeseq/dev/testdata/relevel.tsv'
     genelist = 'https://raw.githubusercontent.com/qbic-pipelines/rnadeseq/dev/testdata/requested_genes.txt'
     //report_options = 'https://raw.githubusercontent.com/qbic-pipelines/rnadeseq/dev/testdata/report_options.yml'
     project_summary = 'https://raw.githubusercontent.com/qbic-pipelines/rnadeseq/dev/testdata/summary.tsv'


### PR DESCRIPTION
This PR changes the relevel github file path to the qbic-pipelines repo

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnadeseq/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/rnadeseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
