### PR TITLE
Fixed heatmaps and removed kaleido from container

### DIFF
--- a/.github/workflows/push_github_container_reg.yml
+++ b/.github/workflows/push_github_container_reg.yml
@@ -9,8 +9,8 @@ on:
     types: [published]
 
 jobs:
-  push_dockerhub:
-    name: Push new Docker image to Docker Hub
+  push_github:
+    name: Push new Docker image to GHCR
     runs-on: ubuntu-latest
     # Only run for the qbic-pipelines repo, for releases and merged PRs
     if: ${{ github.repository == 'qbic-pipelines/rnadeseq' }}

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -20,7 +20,6 @@ lint:
     - .github/ISSUE_TEMPLATE/config.yml
     - .github/workflows/awsfulltest.yml
     - .github/workflows/awstest.yml
-    - .github/workflows/push_dockerhub.yml
     - assets/multiqc_config.yaml
     - assets/nf-core-qbic-pipelines/rnadeseq_logo_light.png
     - bin/markdown_to_html.r

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#211](https://github.com/qbic-pipelines/rnadeseq/pull/21) Replaced heatmaply with pheatmap for static plots and removed kaleido and reticulate from container
 - [#209](https://github.com/qbic-pipelines/rnadeseq/pull/209) Template update to 2.9, Chromium Falcon; exchanged file.exists for nf-core validation checks; changed round_DE param to int
 - [#206](https://github.com/qbic-pipelines/rnadeseq/pull/206) Changed < and > to <= and => for logF/pval comparisons, renamed gene_counts_tables/deseq2_library_scaled_gene_counts.tsv to deseq2_library_scaled_gene_counts.tsv and added entry to the folder explanation; renamed param pval_threshold to adj_pval_threshold
 - [#205](https://github.com/qbic-pipelines/rnadeseq/pull/205) Template update

--- a/assets/RNAseq_report.Rmd
+++ b/assets/RNAseq_report.Rmd
@@ -220,9 +220,6 @@ invisible( lapply(c(
 "tools",
 "yaml"
 ), library, character.only=T))
-
-# Import python sys so that the save_image command works
-reticulate::py_run_string("import sys")
 ```
 
 ```{r create_outdirs, echo=FALSE, message=FALSE, warning=FALSE, results = 'hide'}
@@ -1065,14 +1062,24 @@ sampleDists <- dist(t(assay(if (run_rlog) rld else vsd)))
 sampleDistMatrix <- as.matrix(sampleDists)
 colors = colorRampPalette(rev(RColorBrewer::brewer.pal(9, "Blues")))(255)
 par(oma=c(3,3,3,3))
+dist_heatmap <- pheatmap(mat = sampleDistMatrix, color=colors)
+
+svg("differential_gene_expression/plots/Heatmaps_of_distances.svg")
+dist_heatmap
+dev.off()
+png("differential_gene_expression/plots/Heatmaps_of_distances.png")
+dist_heatmap
+dev.off()
+pdf("differential_gene_expression/plots/Heatmaps_of_distances.pdf")
+dist_heatmap
+dev.off()
+
+# Recompute heatmap with heatmaply for interactive plot in report
 dist_heatmap <- heatmaply(sampleDistMatrix, dendrogram = "both", col=colors, grid_color = "grey")
-save_image(dist_heatmap, file="differential_gene_expression/plots/Heatmaps_of_distances.pdf")
-save_image(dist_heatmap, file="differential_gene_expression/plots/Heatmaps_of_distances.png")
-save_image(dist_heatmap, file="differential_gene_expression/plots/Heatmaps_of_distances.svg")
 ```
 
 ```{r heatmap_show, echo=FALSE, message=FALSE, warning=FALSE, out.width="90%", out.height="130%", fig.asp=1, dpi=1000, fig.align='center'}
-#add export button to plot
+# Add export button to plot
 dist_heatmap %>% layout(height=700, width=800) %>% config(modeBarButtonsToAdd = list(svg_exp))
 ```
 

--- a/assets/RNAseq_report.Rmd
+++ b/assets/RNAseq_report.Rmd
@@ -209,7 +209,6 @@ invisible( lapply(c(
 "kableExtra",
 "knitr",
 "formattable",
-"plotly",
 "webshot",
 "htmlwidgets",
 "pheatmap",

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,6 @@ dependencies:
   - bioconda::bioconductor-tximport=1.22.0
   - bioconda::bioconductor-vsn=3.62.0
   - conda-forge::pandoc=2.17.1.1
-  - conda-forge::plotly=5.13.0 #this is necessary for exporting plots with save_image()
   - conda-forge::r-base=4.1.2
   - conda-forge::r-details=0.3.0
   - conda-forge::r-dplyr=1.0.10

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,6 @@ dependencies:
   - bioconda::bioconductor-vsn=3.62.0
   - conda-forge::pandoc=2.17.1.1
   - conda-forge::plotly=5.13.0 #this is necessary for exporting plots with save_image()
-  - conda-forge::python-kaleido=0.2.1 #this is necessary for exporting plots with save_image()
   - conda-forge::r-base=4.1.2
   - conda-forge::r-details=0.3.0
   - conda-forge::r-dplyr=1.0.10
@@ -42,7 +41,6 @@ dependencies:
   - conda-forge::r-plyr=1.8.6
   - conda-forge::r-rcolorbrewer=1.1_2
   - conda-forge::r-reshape2=1.4.4
-  - conda-forge::r-reticulate=1.28 #this is necessary for exporting heatmaply plots with save_image()
   - conda-forge::r-rmarkdown=2.11
   - conda-forge::r-sessioninfo=1.2.2
   - conda-forge::r-svglite=2.1.0


### PR DESCRIPTION
The kaleido package recently stopped working in the container; it was used for the save_image() function to export heatmaply plots. This PR exchanges those heatmaps for plots done with pheatmap so they can be saved without the function

<!--
# qbic-pipelines/rnadeseq pull request

Many thanks for contributing to qbic-pipelines/rnadeseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/qbic-pipelines/rnadeseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnadeseq/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/rnadeseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
