### PR TITLE
Fix new multiqc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#236](https://github.com/qbic-pipelines/rnadeseq/pull/236) Fixed new multiqc check (in case both the files of the old and new mqc version are present)
 - [#228](https://github.com/qbic-pipelines/rnadeseq/pull/228) Fixed text in report
 - [#229](https://github.com/qbic-pipelines/rnadeseq/pull/229) Fixed cutoff enrichment plot labels, fixed wrong plotMA function being called (also fixed this changelog)
 - [#225](https://github.com/qbic-pipelines/rnadeseq/pull/225) Fixed too many devices error from tryCatch around normalized heatmaps

--- a/assets/RNAseq_report.Rmd
+++ b/assets/RNAseq_report.Rmd
@@ -371,7 +371,7 @@ metadata$Secondary.Name <- gsub(" ; ", "_", metadata$Secondary.Name)
 metadata$Secondary.Name <- gsub(" ", "_", metadata$Secondary.Name)
 metadata$sampleName = paste(row.names(metadata),metadata$Secondary.Name,sep="_")
 row.names(metadata) = metadata$sampleName
-metadata_save <- metadata
+metadata_save <- metadata # save copy so that original metadata object can be changed
 
 if (params$input_type == "smrnaseq") {
 
@@ -872,12 +872,46 @@ for (i in resultsNames(cds)[-1]) {
 # Check first if a new or old multiqc file was provided
 if (file.exists(paste0(wd,"/QC/multiqc_data/multiqc_general_stats.txt"))) {
     mqc_stats <- read.table(file = paste0(wd,"/QC/multiqc_data/multiqc_general_stats.txt"), header=TRUE, sep="\t")
-    mqc_version <- 'old_mqc'
+    columns <- c(
+            "Sample",
+            "FastQC_mqc.generalstats.fastqc.total_sequences",
+            "FastQC_mqc.generalstats.fastqc.percent_duplicates",
+            "FastQC_mqc.generalstats.fastqc.percent_gc",
+            "Cutadapt_mqc.generalstats.cutadapt.percent_trimmed",
+            "STAR_mqc.generalstats.star.uniquely_mapped_percent",
+            "featureCounts_mqc.generalstats.featurecounts.percent_assigned"
+        )
+    if (all(columns %in% colnames(mqc_stats))) {
+        mqc_version <- 'old_mqc'
+    } else if (file.exists(paste0(wd,"/QC/multiqc_data/multiqc_samtools_stats.txt"))) {
+        mqc_stats <- read.table(file = paste0(wd,"/QC/multiqc_data/multiqc_samtools_stats.txt"), header=TRUE, sep="\t")
+        columns <- c(
+                "Sample",
+                "raw_total_sequences",
+                "reads_mapped_percent",
+                "reads_duplicated_percent"
+            )
+        if (all(columns %in% colnames(mqc_stats))) {
+            mqc_version <- 'new_mqc'
+        } else {
+            stop("Could not find a suitable multiqc table; please provide a correct multiqc.zip file or omit the parameter --multiqc altogether.")
+        }
+    }
 } else if (file.exists(paste0(wd,"/QC/multiqc_data/multiqc_samtools_stats.txt"))) {
     mqc_stats <- read.table(file = paste0(wd,"/QC/multiqc_data/multiqc_samtools_stats.txt"), header=TRUE, sep="\t")
-    mqc_version <- 'new_mqc'
+    columns <- c(
+            "Sample",
+            "raw_total_sequences",
+            "reads_mapped_percent",
+            "reads_duplicated_percent"
+        )
+    if (all(columns %in% colnames(mqc_stats))) {
+        mqc_version <- 'new_mqc'
+    } else {
+        stop("Could not find a suitable multiqc table; please provide a correct multiqc.zip file or omit the parameter --multiqc altogether.")
+    }
 } else {
-    stop("Could not find a suitable multiqc table; please provide a correct multiqc.zip file or omit the parameter altogether")
+    stop("Could not find a suitable multiqc table; please provide a correct multiqc.zip file or omit the parameter --multiqc altogether.")
 }
 
 cat(paste0("***
@@ -911,16 +945,6 @@ sum_NA <- function(x) {if (all(is.na(x))) x[NA_integer_] else sum(x, na.rm = TRU
 avg_NA <- function(x) {if (all(is.na(x))) x[NA_integer_] else mean(x, na.rm = TRUE)} # Function to average across rows if available, else NA
 
 if (mqc_version == 'old_mqc') {
-    columns <- c(
-            "Sample",
-            "FastQC_mqc.generalstats.fastqc.total_sequences",
-            "FastQC_mqc.generalstats.fastqc.percent_duplicates",
-            "FastQC_mqc.generalstats.fastqc.percent_gc",
-            "Cutadapt_mqc.generalstats.cutadapt.percent_trimmed",
-            "STAR_mqc.generalstats.star.uniquely_mapped_percent",
-            "featureCounts_mqc.generalstats.featurecounts.percent_assigned"
-        )
-
     table_complete <- mqc_stats[,columns] %>%
         group_by(Sample) %>%
         dplyr::summarize(
@@ -928,13 +952,6 @@ if (mqc_version == 'old_mqc') {
             across(everything(), avg_NA)
         )
 } else {
-    columns <- c(
-            "Sample",
-            "raw_total_sequences",
-            "reads_mapped_percent",
-            "reads_duplicated_percent"
-        )
-
     table_complete <- mqc_stats[,columns] %>%
         group_by(Sample) %>%
         dplyr::summarize(


### PR DESCRIPTION
Add logic to better check which multiqc version is provided (sometimes both the old and the new table file are present in the mqc).

<!--
# qbic-pipelines/rnadeseq pull request

Many thanks for contributing to qbic-pipelines/rnadeseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/qbic-pipelines/rnadeseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/qbic-pipelines/rnadeseq/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
