### PR TITLE
3 - Write background list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## dev
+
+### Added
+
+- [#245](https://github.com/qbic-pipelines/rnadeseq/pull/245) Added background gene list to pathway analysis output
+
 ## 2.3 - Flowering Orchards
 
 ### Added

--- a/assets/RNAseq_report.Rmd
+++ b/assets/RNAseq_report.Rmd
@@ -1969,13 +1969,15 @@ if (isProvided(params$datasources)) {
 min_DEG_pathway <- as.integer(params$min_DEG_pathway)
 
 # If background list is to be used, load custom background list
-# if provided, else use notAllZero
+# if provided, else use notAllZero -->then save to output
 if (isProvided(params$set_background)) {
     if (isProvided(params$custom_background)) {
         custom_background <- readLines(params$custom_background)
     } else {
         custom_background <- rownames(counts(cds))[notAllZero]
     }
+    dir.create("pathway_analysis/metadata")
+    write.table(custom_background, "pathway_analysis/metadata/custom_background.txt", quote=F, row.names = F, col.names = F)
 }
 
 # Contrast files
@@ -2367,6 +2369,12 @@ if (isProvided(params$path_genelist)){
 ```
 
 ```{r pathway_analysis, echo=FALSE, results='asis', eval=params$pathway_analysis}
+
+if (isProvided(params$set_background)) {
+    background_list_text <- "The background gene list used for pathway analysis is saved [here](./pathway_analysis/metadata/custom_background.txt)"
+} else {
+    background_list_text <- ""
+}
 
 if (mv_status) {
     if (isProvided(params$custom_gmt)) {


### PR DESCRIPTION
Added background list to output for reproducibility, removed hard-coded gprofiler DBs from report.
Also slightly changed the report text that shows when the gprofiler GMT file could not be downloaded so that it integrates better into the surrounding text.
This PR directly raises the pipeline version to 2.4 instead of setting it to dev as I will release after this PR


<!--
# qbic-pipelines/rnadeseq pull request

Many thanks for contributing to qbic-pipelines/rnadeseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/qbic-pipelines/rnadeseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/qbic-pipelines/rnadeseq/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
