### PR TITLE
Add trycatch to enrichment plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - [#247](https://github.com/qbic-pipelines/rnadeseq/pull/247) Removed hard-coded comment about usage of gprofiler databases KEGG and REAC in the report
+
 ## 2.3 - Flowering Orchards
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [#255](https://github.com/qbic-pipelines/rnadeseq/pull/255) Add usage docu for datasources, heatmaps_cluster_rows/cols and pathway_adj_pval_threshold params
 - [#251](https://github.com/qbic-pipelines/rnadeseq/pull/251) Get raw gene count tables from either Salmon and RSEM analysis
 - [#250](https://github.com/qbic-pipelines/rnadeseq/pull/250) Added clearer error message for incorrect contrast_pairs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [#256](https://github.com/qbic-pipelines/rnadeseq/pull/256) Add trycatch to pathway enrichment plots so they are skipped when too large instead of throwing an error
 - [#255](https://github.com/qbic-pipelines/rnadeseq/pull/255) Add usage docu for datasources, heatmaps_cluster_rows/cols and pathway_adj_pval_threshold params
 - [#251](https://github.com/qbic-pipelines/rnadeseq/pull/251) Get raw gene count tables from either Salmon and RSEM analysis
 - [#250](https://github.com/qbic-pipelines/rnadeseq/pull/250) Added clearer error message for incorrect contrast_pairs

--- a/assets/RNAseq_report.Rmd
+++ b/assets/RNAseq_report.Rmd
@@ -2227,9 +2227,32 @@ for (file in contrast_files){
                 scale_fill_continuous(high = "#132B43", low = "#56B1F7") +
                 ggtitle("Enriched pathways") +
                 xlab("") + ylab("Gene fraction (DE genes / Pathway size)")
-            ggsave(p, filename = paste0("pathway_analysis", "/", fname, "/enrichment_plots/", make.names(db_source), "_pathway_enrichment_plot.pdf"), device = "pdf", height = 5+0.5*nrow(df_subset), units = "cm", limitsize=F)
-            ggsave(p, filename = paste0("pathway_analysis", "/", fname, "/enrichment_plots/", make.names(db_source), "_pathway_enrichment_plot.png"), device = "png", height = 5+0.5*nrow(df_subset), units = "cm", limitsize=F)
-            ggsave(p, filename = paste0("pathway_analysis", "/", fname, "/enrichment_plots/", make.names(db_source), "_pathway_enrichment_plot.svg"), device = "svg", height = 5+0.5*nrow(df_subset), units = "cm", limitsize=F)
+
+            # If the plots are huge ggsave will throw an error even if limitsize=T, so I'm leaving limitsize=F and instead using trycatch
+            tryCatch(
+                {
+                    ggsave(p, filename = paste0("pathway_analysis", "/", fname, "/enrichment_plots/", make.names(db_source), "_pathway_enrichment_plot.pdf"), device = "pdf", height = 5+0.5*nrow(df_subset), units = "cm", limitsize=F)
+                },
+                error=function(e) {
+                    print(paste0("Could not save pathway_analysis", "/", fname, "/enrichment_plots/", make.names(db_source), "_pathway_enrichment_plot.pdf because of the following error:\n", e))
+                }
+            )
+            tryCatch(
+                {
+                    ggsave(p, filename = paste0("pathway_analysis", "/", fname, "/enrichment_plots/", make.names(db_source), "_pathway_enrichment_plot.png"), device = "png", height = 5+0.5*nrow(df_subset), units = "cm", limitsize=F)
+                },
+                error=function(e) {
+                    print(paste0("Could not save pathway_analysis", "/", fname, "/enrichment_plots/", make.names(db_source), "_pathway_enrichment_plot.png because of the following error:\n", e))
+                }
+            )
+            tryCatch(
+                {
+                    ggsave(p, filename = paste0("pathway_analysis", "/", fname, "/enrichment_plots/", make.names(db_source), "_pathway_enrichment_plot.svg"), device = "svg", height = 5+0.5*nrow(df_subset), units = "cm", limitsize=F)
+                },
+                error=function(e) {
+                    print(paste0("Could not save pathway_analysis", "/", fname, "/enrichment_plots/", make.names(db_source), "_pathway_enrichment_plot.svg because of the following error:\n", e))
+                }
+            )
 
             # Plotting heatmaps and KEGG pathways for all pathways
             print("Plotting heatmaps...")
@@ -2412,7 +2435,7 @@ Inside the pathway analysis results folder, a subfolder for each contrast used f
 - `*_gost_pathway_venn_diagram.pdf/png`
     - Venn diagrams showing the numbers of enriched pathways when using a background gene list vs when not using a bg list.
 - `enrichment_plots/*_pathway_enrichment_plot.{pdf/png/svg}`
-    - Barplots showing the proportion of differentially expressed genes in the pathway for a certain pathway database.
+    - Barplots showing the proportion of differentially expressed genes in the pathway for a certain pathway database (might be missing if too many pathways were enriched for fitting into a plot).
 - `gost_pathway_gostplot.{pdf/png/svg}`
     - Manhattan plots displaying all enriched pathways.
 - `KEGG_pathways/`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -34,6 +34,9 @@
   - [`--vst_genes_number`](#--vst_genes_number)
   - [`--round_DE`](#--round_DE)
   - [`--run_pathway_analysis`](#--run_pathway_analysis)
+  - [`--pathway_adj_pval_threshold`](#--pathway_adj_pval_threshold)
+  - [`--heatmaps_cluster_rows`](#--heatmaps_cluster_rows)
+  - [`--heatmaps_cluster_cols`](#--heatmaps_cluster_cols)
   - [`--input_type`](#--input_type)
   - [`--multiqc`](#--multiqc)
   - [`--project_summary`](#--project_summary)
@@ -48,6 +51,7 @@
   - [`--custom_gmt`](#--custom_gmt)
   - [`--set_background`](#--set_background)
   - [`--custom_background`](#--custom_background)
+  - [`--datasources`](#--datasources)
   - [`--igenomes_base`](#--igenomes_base)
   - [`--igenomes_ignore`](#--igenomes_ignore)
 - [Job resources](#job-resources)
@@ -373,6 +377,18 @@ Integer indicating to how many decimals to round the DE results (default: -1, in
 
 Set this flag to run pathway analysis, otherwise, this step will be skipped.
 
+### `--pathway_adj_pval_threshold`
+
+Use this param to specifically set the adjusted p value threshold for pathway enrichment analysis (will otherwise use the same adjusted p value threshold as for the DE analysis, as set with the param `--adj_pval_threshold`).
+
+### `--heatmaps_cluster_rows`
+
+Use this flag to set whether the heatmaps of gene expression in enriched pathways should by clustered row-wise (default true).
+
+### `--heatmaps_cluster_cols`
+
+Use this flag to set whether the heatmaps of gene expression in enriched pathways should by clustered column-wise (default false).
+
 ### `--input_type`
 
 This tells the pipeline which type of input dataset is provided. Must be one of 'featurecounts', 'rsem', 'salmon', 'smrnaseq', default: featurecounts.
@@ -449,6 +465,10 @@ Whether to restrict pathway analysis to a background gene list (default: true, w
 ### `--custom_background`
 
 Path to custom background TXT file with one gene ID per line to use as background genes, not necessary if `--run_pathway_analysis = false` or `--set_background = false`.
+
+### `--datasources`
+
+Which datasources to use for pathway analysis, comma-separated string like 'KEGG,REAC'. See param 'sources' on https://rdrr.io/cran/gprofiler2/man/gost.html for a list of available sources. If not set, will use all sources. If set while a --custom_gmt is provided, will filter the GMT for these datasources (will not filter for the GO subtypes like GO:BP, just for GO).
 
 ## Job resources
 


### PR DESCRIPTION
For pathway analyses where many pathways are enriched, the ggsave function throws an error when trying to save the enrichment plots. This PR adds trycatches to allow the pipeline to continue; the plots are in such a case not saved

<!--
# qbic-pipelines/rnadeseq pull request

Many thanks for contributing to qbic-pipelines/rnadeseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/qbic-pipelines/rnadeseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/qbic-pipelines/rnadeseq/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
